### PR TITLE
Get Line Coverage by Functions, not by Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 .coverage
 .pytest*
+/sandbox

--- a/src/cover/cover.py
+++ b/src/cover/cover.py
@@ -7,12 +7,74 @@ from collections import defaultdict
 from coverage.misc import NoSource
 import os
 
+class Function:
+    def __init__(self, file_path:str, name:str, start: int, end: int):
+        self.file_path = file_path
+        self.name = name
+        self.start = start
+        self.end = end # line number of the last line that belongs to the function
+    
+    def __str__(self):
+        return f"Function '{self.name}' at file {self.file_path}: {self.start} - {self.end}"
+    
+    def getHash(self):
+        return hexdigest(f"{self.file_path}{self.name}{self.start}{self.end}")
+
+def get_indent(line:str)->int:
+    indent = 0
+    space_counter = 0
+    for char in line:
+        if char == "\t":
+            indent+=1
+        elif char==" ":
+            space_counter +=1
+        else:
+            break
+    assert not (indent and space_counter), "inconsistent use of tab and spaces for indentation"
+    return max(indent, space_counter//4)
+
+def get_functions(root_path:str)->List[Function]:
+        assert root_path.split(".")[-1] =="py", "file is not python file"
+        f = open(root_path,"r")
+
+        # initialize
+        s = -1
+        e = -1
+        indent = -1
+        name = ""
+        functions = []
+
+        lines = f.readlines()
+        for l in range(len(lines)):
+            line = lines[l]
+            if line.lstrip().startswith("def"):
+                s = l
+                name = line.strip().split()[1].split("(")[0]
+                indent = get_indent(line)
+            elif s!=-1 and not line.lstrip().startswith("#") and line.strip() != "":
+                # condition for the function to end
+                if get_indent(line)<=indent:
+                    assert e!=-1 and e>s, "function declared, but contains nothing"
+                    function = Function(root_path,name,s+1,e+1)
+                    functions.append(function)
+                    s = -1
+                    e = -1
+                    name =""
+                    indent = -1
+                # meaningful line inside the function
+                else:
+                    e=l
+        # function ends at the end of file.
+        if s!=-1:
+            function = Function(root_path,name, s+1,e+1)
+            functions.append(function)
+        return functions
 
 class Line:
     def __init__(self, file_path: str, line_no: int, text: str):
         self.file_path = file_path
         self.line_no = line_no
-        self.text = text[:-1]
+        self.text = text.rstrip()
 
     def getHash(self):
         return hexdigest(f"{self.file_path}{self.line_no}{self.text}")
@@ -26,9 +88,7 @@ class Line:
     def get_file_path(self):
         return self.file_path
 
-
 class Cover:
-
     @staticmethod
     def get_coverage(args: list, root_path: str, module_use=False) -> Dict[str, Line]:
         """
@@ -85,3 +145,33 @@ class Cover:
                     f.close()
 
             return covered
+
+    def get_function_coverage(root_path:str, covered_lines:Dict[str,Line])->Dict[Function,List[Line]]:
+        """
+        Returns Dict of covered lines organised by the function they belong to.
+         :param root_path: target src root want to get coverage
+         :return: {
+             Function1_Hash: [{file_path,line_no,line_text}, {file_path, line_no, line_text}],
+             Function2_Hash: [{file_path,line_no,line_text}, {file_path, line_no, line_text}]
+         }
+        1. Functions containing at least one covered line will be a key of this dictionary (precisely, its hash will be the key)
+        2. All lines in a function that are covered can be found as a list of Line objects, under the key being the hash of the function
+        3. Line(line text, line no, file path)
+        4. res_dict[Function.getHash()] = List[Line]
+        5. return res_dict
+        """
+        functions = get_functions(root_path)
+        covered_function_info = dict()
+        lines = list(covered_lines.values())
+        for function in functions:
+            #file_path, line_no, text
+            covered_lines_in_function = []
+            for line in lines:
+                if line.file_path == function.file_path and line.line_no >= function.start and line.line_no <= function.end:
+                    covered_lines_in_function.append(line)
+            if len(covered_lines_in_function) > 0:
+                covered_function_info[function.getHash()] = covered_lines_in_function
+
+        return covered_function_info
+            
+            

--- a/src/cover/cover.py
+++ b/src/cover/cover.py
@@ -88,7 +88,9 @@ class Line:
     def get_file_path(self):
         return self.file_path
 
+
 class Cover:
+
     @staticmethod
     def get_coverage(args: list, root_path: str, module_use=False) -> Dict[str, Line]:
         """

--- a/tests/cover/test_cover.py
+++ b/tests/cover/test_cover.py
@@ -3,8 +3,6 @@ from src.diff.hashcash import hexdigest
 import os
 import pytest
 
-# def test_true():
-#     assert 1 == 1
 
 def test_get_coverage_pytest():
     fn = 'test_line.py'

--- a/tests/cover/test_cover.py
+++ b/tests/cover/test_cover.py
@@ -66,4 +66,23 @@ def test_get_functions():
     dir_path = os.path.dirname(os.path.realpath(__file__))
     fn_path = os.path.join(dir_path, fn)
 
-    assert get_functions(fn_path)[0].name=="test_line", "get functions failed"
+    functions = get_functions(fn_path)
+    assert functions[0].name=="test_line", "get functions failed"
+
+    covered = Cover.get_coverage(args=['pytest', os.path.join(dir_path, fn)],
+                                root_path=os.path.join(dir_path, "../../"),
+                                module_use=True)
+
+    function_covered = Cover.get_function_coverage(root_path=os.path.join(dir_path, "../../"), covered)
+
+    file_path = os.path.abspath(fn_path)
+    name = "test_line"
+    start =4
+    end = 16
+    covered_key = hexdigest(f"{file_path}{name}{start}{end}")
+    line_no = 8
+    text = "    line = Line(filepath, line_no, line_text)"
+    line_object = Line(file_path,line_no,text)
+
+    assert covered_key in function_covered.keys(), "function test_line should have been covered, but function coverage didn't catch that."
+    assert line_object in function_covered[covered_key], "function was covered, but covered lines were not classified well enough."

--- a/tests/cover/test_cover.py
+++ b/tests/cover/test_cover.py
@@ -1,9 +1,10 @@
-from src.cover.cover import Cover
+from src.cover.cover import Cover, get_indent, get_functions
 from src.diff.hashcash import hexdigest
 import os
 import pytest
 
-
+# def test_true():
+#     assert 1 == 1
 
 def test_get_coverage_pytest():
     fn = 'test_line.py'
@@ -58,3 +59,13 @@ def test_covered_or_not():
                 with pytest.raises(TypeError):
                     covered[uncovered_key]
         f.close()
+
+def test_get_functions():
+    assert get_indent("\td") == 1, "get indent with tab failed"
+    assert get_indent("    d") == 1, "get indent with space failed,"
+
+    fn = 'test_line.py'
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    fn_path = os.path.join(dir_path, fn)
+
+    assert get_functions(fn_path)[0].name=="test_line", "get functions failed"

--- a/tests/cover/test_function.py
+++ b/tests/cover/test_function.py
@@ -1,0 +1,16 @@
+from src.cover.cover import Function
+
+
+def test_function():
+    filepath = "/path/to/python/test.py"
+    start=112
+    end = 113
+    name = "foo"
+    func = Function(filepath, name, start, end)
+    func.getHash()
+    assert str(func) == f"Function '{name}' at file {filepath}: {start} - {end}"
+    
+    if str(func) == f"Function '{name}' at file {filepath}: {start} - {end}":
+        print("If branch. This should be printed")
+    else:
+        print("Else branch. This should not be printed")


### PR DESCRIPTION
For each file, the covered lines will be classified into the functions they belong to.

Coverage Structure (@get_function coverage, Cover, src.cover.cover)
The hash of the Function object will be the key, the value will be the list of Line objects of the covered lines.

TEST NOT YET FULLY IMPLEMENTED
Crucial errors have been detected with the get_coverage method of class Cover. Tests for the get_function_coverage method require get_coverage to run correctly, as the new function uses its output as parameter. Tests will be implemented after this issue is solved.